### PR TITLE
Fix state hook bug

### DIFF
--- a/src/hooks/useChatState.js
+++ b/src/hooks/useChatState.js
@@ -14,7 +14,12 @@ export function useChatState() {
     step: 0,
     input: '',
     showReview: false,
-    playlistPreviews: []
+    playlistPreviews: [],
+    // Additional UI state that isn't persisted to localStorage by default
+    showPreviews: false,
+    loadingPreviews: false,
+    previewError: null,
+    userType: 'BMAsia Client'
   };
 
   // Initialize state variables
@@ -23,6 +28,10 @@ export function useChatState() {
   const [input, setInput] = useState(defaultState.input);
   const [showReview, setShowReview] = useState(defaultState.showReview);
   const [playlistPreviews, setPlaylistPreviews] = useState(defaultState.playlistPreviews);
+  const [showPreviews, setShowPreviews] = useState(defaultState.showPreviews);
+  const [loadingPreviews, setLoadingPreviews] = useState(defaultState.loadingPreviews);
+  const [previewError, setPreviewError] = useState(defaultState.previewError);
+  const [userType, setUserType] = useState(defaultState.userType);
 
   // On mount, attempt to load state from localStorage
   useEffect(() => {
@@ -35,6 +44,10 @@ export function useChatState() {
         if (typeof parsed.input === 'string') setInput(parsed.input);
         if (typeof parsed.showReview === 'boolean') setShowReview(parsed.showReview);
         if (Array.isArray(parsed.playlistPreviews)) setPlaylistPreviews(parsed.playlistPreviews);
+        if (typeof parsed.showPreviews === 'boolean') setShowPreviews(parsed.showPreviews);
+        if (typeof parsed.loadingPreviews === 'boolean') setLoadingPreviews(parsed.loadingPreviews);
+        if (typeof parsed.previewError === 'string' || parsed.previewError === null) setPreviewError(parsed.previewError);
+        if (typeof parsed.userType === 'string') setUserType(parsed.userType);
       } catch (e) {
         // If parsing fails, ignore and use defaults
         console.error('Failed to parse saved chat state:', e);
@@ -72,6 +85,10 @@ export function useChatState() {
     step, setStep,
     input, setInput,
     showReview, setShowReview,
-    playlistPreviews, setPlaylistPreviews
+    playlistPreviews, setPlaylistPreviews,
+    showPreviews, setShowPreviews,
+    loadingPreviews, setLoadingPreviews,
+    previewError, setPreviewError,
+    userType, setUserType
   };
 }

--- a/src/hooks/useChatState.test.js
+++ b/src/hooks/useChatState.test.js
@@ -21,6 +21,10 @@ describe('useChatState hook', () => {
     expect(result.current.input).toBe('');
     expect(result.current.showReview).toBe(false);
     expect(result.current.playlistPreviews).toEqual([]);
+    expect(result.current.showPreviews).toBe(false);
+    expect(result.current.loadingPreviews).toBe(false);
+    expect(result.current.previewError).toBe(null);
+    expect(result.current.userType).toBe('BMAsia Client');
     /*
       This test checks that the hook uses default values if nothing is saved,
       ensuring a predictable experience for first-time users.
@@ -60,6 +64,10 @@ describe('useChatState hook', () => {
       result.current.setInput('chill');
       result.current.setShowReview(true);
       result.current.setPlaylistPreviews([{ label: 'Evening Energy', link: '#' }]);
+      result.current.setShowPreviews(true); // should not persist
+      result.current.setLoadingPreviews(true); // should not persist
+      result.current.setPreviewError('oops'); // should not persist
+      result.current.setUserType('External User'); // optional to persist
     });
     // Check that localStorage was updated with new state
     const saved = JSON.parse(localStorage.getItem('playlistBuilderState'));
@@ -68,6 +76,12 @@ describe('useChatState hook', () => {
     expect(saved.input).toBe('chill');
     expect(saved.showReview).toBe(true);
     expect(saved.playlistPreviews).toEqual([{ label: 'Evening Energy', link: '#' }]);
+    // Transient state should not be saved
+    expect(saved.showPreviews).toBeUndefined();
+    expect(saved.loadingPreviews).toBeUndefined();
+    expect(saved.previewError).toBeUndefined();
+    // User type isn't persisted by default
+    expect(saved.userType).toBeUndefined();
     /*
       This test checks that any progress is saved as state changes,
       so user progress isn't lost if the page is refreshed.


### PR DESCRIPTION
## Summary
- expose additional state from `useChatState`
- test that the hook provides these defaults and that transient state does not persist

## Testing
- `npm test` *(fails: no test specified)*